### PR TITLE
Fix: Correct cmdparser patch application and improve CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ FetchContent_Declare(
   cmdparser
   GIT_REPOSITORY https://github.com/FlorianRappl/CmdParser.git
   GIT_TAG        v1.1.0
-  PATCH_COMMAND git apply --ignore-space-change --ignore-whitespace ${CMAKE_CURRENT_SOURCE_DIR}/patches/cmdparser/CMakeLists.txt.patch
+  PATCH_COMMAND git apply --ignore-space-change --ignore-whitespace "${CMAKE_CURRENT_SOURCE_DIR}/patches/cmdparser/CMakeLists.txt.patch"
 
 )
 FetchContent_MakeAvailable(cmdparser)
@@ -45,12 +45,11 @@ add_dependencies(DialLog usb-1.0)
 # --- Link Your Application to libusb ---
 # This tells the linker *what* to link with DialLog.
 # The dependency created by add_dependencies ensures usb-1.0 exists when linking occurs.
-target_link_libraries(DialLog PRIVATE usb-1.0)
+target_link_libraries(DialLog PRIVATE usb-1.0 cmdparser)
 
 # --- Include Directories ---
 # Add libusb's include directory to your application's include path
-target_include_directories(DialLog PRIVATE ${libusb_SOURCE_DIR}/libusb/libusb)
-target_include_directories(DialLog PRIVATE ${cmdparser_SOURCE_DIR}/)
+target_include_directories(DialLog PRIVATE "${libusb_SOURCE_DIR}/libusb/libusb")
 
 # --- Build Configuration Specifics (Optional but Recommended) ---
 if(MSVC)

--- a/patches/cmdparser/CMakeLists.txt.patch
+++ b/patches/cmdparser/CMakeLists.txt.patch
@@ -1,11 +1,9 @@
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index a3eb0e6..dc4ed45 100644
---- a/CMakeLists.txt 
-+++ b/CMakeLists.txt
+--- a/CMakeLists.txt	2025-05-27 23:25:42.501012874 +0000
++++ b/CMakeLists.txt	2025-05-27 23:25:42.501012874 +0000
 @@ -1,6 +1,13 @@
  cmake_minimum_required(VERSION 3.9)
  project(cmdparser)
-
+ 
 +# Create a header only library and explicitly specify the include directory
 +# for consumers of the library
 +add_library(${PROJECT_NAME} INTERFACE)
@@ -14,5 +12,5 @@ index a3eb0e6..dc4ed45 100644
 +)
 +
  enable_testing()
-
+ 
  set(CMAKE_CXX_STANDARD 11)


### PR DESCRIPTION
The CMake configuration was failing because the patch file for the
`cmdparser` dependency was outdated and could not be applied to v1.1.0
of the library.

This commit introduces the following changes:
- Updated `patches/cmdparser/CMakeLists.txt.patch` to correctly align
  with the `cmdparser` v1.1.0 `CMakeLists.txt` structure. The patch
  modifies `cmdparser` to be an INTERFACE (header-only) library.
- Corrected the file path headers within the patch file to the standard
  `a/` and `b/` format required by `git apply`.
- Ensured the CMake configuration now runs successfully with the
  corrected patch.

Additionally, several minor improvements were made to the main `CMakeLists.txt`:
- Quoted paths in `PATCH_COMMAND` for `cmdparser` and in
  `target_include_directories` for `libusb` to prevent potential issues.
- Modified the project to link against `cmdparser` as an INTERFACE
  library (`target_link_libraries(DialLog PRIVATE cmdparser)`), which is
  the modern CMake way of handling header-only dependencies and their
  include directories, removing the explicit `target_include_directories`
  call for `cmdparser`.